### PR TITLE
Add bold 'Hello World' headline above logo on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,6 +17,7 @@ export default function Home() {
       className={`${geistSans.className} ${geistMono.className} grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]`}
     >
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <h1 className="font-bold text-4xl sm:text-5xl mb-6 font-[family-name:var(--font-geist-sans)]">Hello World</h1>
         <Image
           className="dark:invert"
           src="/next.svg"


### PR DESCRIPTION
- Add a large, bold 'Hello World' h1 headline above the Next.js logo on the home page.
- Styles follow explicit named imports, PascalCase, repo font, and Tailwind utility class requirements.
- No other files touched; fully compatible with structure/design patterns.